### PR TITLE
feat: Write ICS file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,16 @@ Exports an iCal compatible `.ics` file from Logseq TODO entries.
   - Blocks with a time will receive a default duration of 30 minutes
   - Blocks without a time will receive a default end date of the same day
 - Adds page context to calendar entry: `<block content> - <page name>`
-- Generates an ICS into console.log
+- Generates a `.ics` file into `~/.logseq/storages/lomz-ics-export/calendar.ics`
 
 ### TODO
-- [ ] Generates ICS into a file
-  - Blocked on [Plugin Storage API](https://discuss.logseq.com/t/writing-to-a-file-for-ics-export/1453)
+- [x] Generates ICS into a file
+  - Blocked on [Plugin Storage API](https://github.com/logseq/logseq/pull/2399)
 - [ ] Creates recurring events using [RRULEs](https://www.textmagic.com/free-tools/rrule-generator)
 - [ ] UI Panel for configuration
 - Configuration options
   - [ ] Configure TODO filter
+  - [ ] Configure separate calendars
 
 ### Resources
 - [ics](https://www.npmjs.com/package/ics)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "parcel build --public-url . --no-source-maps index.html"
   },
   "logseq": {
-    "id": "_omgdahdee"
+    "id": "lomz-ics-export"
   },
   "dependencies": {
     "@logseq/libs": "^0.0.1-alpha.22",

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -18,7 +18,7 @@ export interface TodoItem {
   // ISO Date
   scheduled?: number;
   uuid: {
-    Xd: string;
+    uuid: string;
   };
 };
 
@@ -132,7 +132,7 @@ export const fetchTodoItems = async (runQuery: (query: any) => Promise<any>): Pr
     // Dedupe the results using uuid.
     let dedupedTodoItems = {};
     results.map(([page, item]) => {
-      let key = item.uuid.Xd;
+      let key = item.uuid.uuid;
       if (dedupedTodoItems[key] == undefined) {
         dedupedTodoItems[key] = [page, item];
         console.log(item);

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -135,7 +135,6 @@ export const fetchTodoItems = async (runQuery: (query: any) => Promise<any>): Pr
       let key = item.uuid.uuid;
       if (dedupedTodoItems[key] == undefined) {
         dedupedTodoItems[key] = [page, item];
-        console.log(item);
       }
     })
     return Object.values(dedupedTodoItems);

--- a/src/ics.ts
+++ b/src/ics.ts
@@ -1,6 +1,10 @@
 import ics, { createEvents, DateArray } from 'ics';
 import {Page, TodoItem, Timestamp, recFindTimestamp} from "./entities";
 
+import '@logseq/libs';
+import { ILSPluginUser } from '@logseq/libs/dist/LSPlugin';
+
+
 export const convertTimestampToDateArray = (timestamp: Timestamp): DateArray => {
   if (timestamp.time) {
     return [
@@ -53,12 +57,16 @@ export const convertTodoToEvent = ([page, item]: [Page, TodoItem]): ics.EventAtt
   });
 };
 
-export const dumpToIcs = (events: ics.EventAttributes[], path: string) => {
+export const dumpToIcs = async (logseq: ILSPluginUser, events: ics.EventAttributes[]) => {
   const ret = createEvents(events);
   if (ret.error) {
     throw new Error(`Unable to dump events to ICS: ${ret.error}`);
   }
 
-  // cannot write a file.
-  console.log(ret.value);
+  if (ret.value) {
+    await logseq.FileStorage.setItem("calendar.ics", ret.value);
+    console.log(`Wrote {events.length} events to calendar.ics`);
+  } else {
+    console.warn("Did not write null ICS file to disk");
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ const syncCalendar = () => {
     const events = items.reduce((acc, item) => {
       return acc.concat(convertTodoToEvent(item))
     }, [])
-    dumpToIcs(events, "/tmp/test.ics")
+    return dumpToIcs(logseq, events)
   });
 };
 


### PR DESCRIPTION
## Background
Writes an ICS file using the new FileStorage API. Gets written to `~/.logseq/storages/lomz-ics-export/calendar.ics`.

Dependent on https://github.com/logseq/logseq/pull/2399

## Changes
- chore: make plugin id not embarrassing
- fix: update uuid format for Block
- feat: use FileStorage to write to file
- chore: remove log
